### PR TITLE
Updated gulpfile.js to support image destination

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,8 +89,8 @@ gulp.task("scripts", ["scripts:fabricator", "scripts:toolkit"]);
 gulp.task("images", function () {
 	return gulp.src("src/toolkit/assets/img/**/*")
 		.pipe(imagemin())
-		.pipe(gulp.dest("dist/toolkit/img")
-		.pipe(gulpif(!gutil.env.production, connect.reload())));
+		.pipe(gulp.dest("dist/toolkit/img"))
+		.pipe(gulpif(!gutil.env.production, connect.reload()));
 });
 
 


### PR DESCRIPTION
Closing paran was on incorrect line causing images to not properly move to gulp.dest
