### PR TITLE
removes duplicate rendering of notes

### DIFF
--- a/src/toolkit/views/components.html
+++ b/src/toolkit/views/components.html
@@ -23,10 +23,6 @@
 					</div>
 				</div>
 
-				<div class="f-item-notes">
-					{{{notes}}}
-				</div>
-
 				<div class="f-item-preview">
 					{{{content}}}
 				</div>

--- a/src/toolkit/views/structures.html
+++ b/src/toolkit/views/structures.html
@@ -23,10 +23,6 @@
 					</div>
 				</div>
 
-				<div class="f-item-notes">
-					{{{notes}}}
-				</div>
-
 				<div class="f-item-preview">
 					{{{content}}}
 				</div>


### PR DESCRIPTION
Since commit 30a8002 adds a condition for the presence of notes, the original div showing f-item-notes is no longer needed
