### PR TITLE
make ASCII doc look nice

### DIFF
--- a/src/assets/fabricator/styles/partials/_code.scss
+++ b/src/assets/fabricator/styles/partials/_code.scss
@@ -27,7 +27,7 @@ pre[class*='language-'] {
 	tab-size: 4;
 	hyphens: none;
 	font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-	line-height: 1.4;
+	line-height: 1.2;
 	direction: ltr;
 	cursor: text;
 }


### PR DESCRIPTION
To allow for ASCII doc, I changed line-height of `code` elements to 1.2

before:

![image](https://cloud.githubusercontent.com/assets/170145/7445882/b384de0a-f1c5-11e4-859a-ff85a0fe49b4.png)


after:

![image](https://cloud.githubusercontent.com/assets/170145/7445887/c0d243f4-f1c5-11e4-95ee-17bcabe7b740.png)
