### PR TITLE
fix: gulp sass watch stops working on error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,7 +49,7 @@ gulp.task('clean', function (cb) {
 
 // styles
 gulp.task('styles:fabricator', function () {
-	return gulp.src(config.src.styles.fabricator)
+	gulp.src(config.src.styles.fabricator)
 		.pipe(sass().on('error', sass.logError))
 		.pipe(prefix('last 1 version'))
 		.pipe(gulpif(!config.dev, csso()))
@@ -59,7 +59,7 @@ gulp.task('styles:fabricator', function () {
 });
 
 gulp.task('styles:toolkit', function () {
-	return gulp.src(config.src.styles.toolkit)
+	gulp.src(config.src.styles.toolkit)
 		.pipe(sass().on('error', sass.logError))
 		.pipe(prefix('last 1 version'))
 		.pipe(gulpif(!config.dev, csso()))


### PR DESCRIPTION
Hello fabricator team,

We started using fabricator recently but noticed there was a problem when compiling our sass files. Gulp sass always stopped watching as soon as a file got saved that contained an error. We found out that a gulp sass has a ticket [#90](https://github.com/dlmanning/gulp-sass/issues/90) that discusses this problem. We applied the fix that is described in their [#90](https://github.com/dlmanning/gulp-sass/wiki/Common-Issues-and-Their-Fixes#gulp-watch-stops-working-on-an-error). This commit contains the modified gulp file.

Would you consider accepting our pull request?

P.S. Congrats your project is great, our desingers love their new toy ;)