### PR TITLE
Adding source maps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,7 @@ gulp.task('styles:fabricator', function () {
 		.pipe(prefix('last 1 version'))
 		.pipe(gulpif(!config.dev, csso()))
 		.pipe(rename('f.css'))
-		.pipe(sourcemaps.write('./'))
+		.pipe(sourcemaps.write())
 		.pipe(gulp.dest(config.dest + '/assets/fabricator/styles'))
 		.pipe(gulpif(config.dev, reload({stream:true})));
 });
@@ -67,7 +67,7 @@ gulp.task('styles:toolkit', function () {
 		.pipe(sass().on('error', sass.logError))
 		.pipe(prefix('last 1 version'))
 		.pipe(gulpif(!config.dev, csso()))
-		.pipe(sourcemaps.write('./'))
+		.pipe(sourcemaps.write())
 		.pipe(gulp.dest(config.dest + '/assets/toolkit/styles'))
 		.pipe(gulpif(config.dev, reload({stream:true})));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ var rename = require('gulp-rename');
 var reload = browserSync.reload;
 var runSequence = require('run-sequence');
 var sass = require('gulp-sass');
+var sourcemaps = require('gulp-sourcemaps');
 var webpack = require('webpack');
 
 
@@ -50,19 +51,23 @@ gulp.task('clean', function (cb) {
 // styles
 gulp.task('styles:fabricator', function () {
 	gulp.src(config.src.styles.fabricator)
+		.pipe(sourcemaps.init())
 		.pipe(sass().on('error', sass.logError))
 		.pipe(prefix('last 1 version'))
 		.pipe(gulpif(!config.dev, csso()))
 		.pipe(rename('f.css'))
+		.pipe(sourcemaps.write('./'))
 		.pipe(gulp.dest(config.dest + '/assets/fabricator/styles'))
 		.pipe(gulpif(config.dev, reload({stream:true})));
 });
 
 gulp.task('styles:toolkit', function () {
 	gulp.src(config.src.styles.toolkit)
+		.pipe(sourcemaps.init())
 		.pipe(sass().on('error', sass.logError))
 		.pipe(prefix('last 1 version'))
 		.pipe(gulpif(!config.dev, csso()))
+		.pipe(sourcemaps.write('./'))
 		.pipe(gulp.dest(config.dest + '/assets/toolkit/styles'))
 		.pipe(gulpif(config.dev, reload({stream:true})));
 });

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-imagemin": "^2.2.1",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.0",
+    "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.4",
     "imports-loader": "^0.6.3",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
Adding source maps to make developing Sass faster, especially when using partials.