### PR TITLE
Fix #156 Menu highlighting per section

### DIFF
--- a/src/assets/fabricator/scripts/fabricator.js
+++ b/src/assets/fabricator/scripts/fabricator.js
@@ -101,8 +101,9 @@ fabricator.setActiveItem = function () {
 	var setActive = function () {
 
 		// get current file and hash without first slash
-		var current = (window.location.pathname + window.location.hash).replace(/(^\/)(.+?)(#[\w\-\.]+)?$/ig, function (match, slash, file, hash) {
+		var current = (window.location.pathname + window.location.hash).replace(/(^\/)([^#]+)?(#[\w\-\.]+)?$/ig, function (match, slash, file, hash) {
 		    	hash = hash || '';
+		    	file = file || '';
 		    	return file + hash.split('.')[0];
 			}) || 'index.html',
 			href;

--- a/src/assets/fabricator/scripts/fabricator.js
+++ b/src/assets/fabricator/scripts/fabricator.js
@@ -96,63 +96,30 @@ fabricator.buildColorChips = function () {
 fabricator.setActiveItem = function () {
 
 	/**
-	 * @return {Array} Sorted array of menu item 'ids'
-	 */
-	var parsedItems = function () {
-
-		var items = [],
-			id, href;
-
-		for (var i = fabricator.dom.menuItems.length - 1; i >= 0; i--) {
-
-			// remove active class from items
-			fabricator.dom.menuItems[i].classList.remove('f-active');
-
-			// get item href
-			href = fabricator.dom.menuItems[i].getAttribute('href');
-
-			// get id
-			if (href.indexOf('#') > -1) {
-				id = href.split('#').pop();
-			} else {
-				id = href.split('/').pop().replace(/\.[^/.]+$/, '');
-			}
-
-			items.push(id);
-
-		}
-
-		return items.reverse();
-
-	};
-
-
-	/**
-	 * Match the 'id' in the window location with the menu item, set menu item as active
+	 * Match the window location with the menu item, set menu item as active
 	 */
 	var setActive = function () {
 
-		var href = window.location.href,
-			items = parsedItems(),
-			id, index;
+		// get current file and hash without first slash
+		var current = (window.location.pathname + window.location.hash).replace(/^\//g, ''),
+			href;
 
-		// get window 'id'
-		if (href.indexOf('#') > -1) {
-			id = window.location.hash.replace('#', '');
-		} else {
-			id = window.location.pathname.split('/').pop().replace(/\.[^/.]+$/, '');
+		// find the current section in the items array
+		for (var i = fabricator.dom.menuItems.length - 1; i >= 0; i--) {
+
+			var item = fabricator.dom.menuItems[i];
+
+			// get item href without first slash
+			href = item.getAttribute('href').replace(/^\//g, '');
+
+			if (href === current) {
+				item.classList.add('f-active');
+			}
+			else {
+				item.classList.remove('f-active');
+			}
+
 		}
-
-		// In case the first menu item isn't the index page.
-		if (id === '') {
-			id = 'index';
-		}
-
-		// find the window id in the items array
-		index = (items.indexOf(id) > -1) ? items.indexOf(id) : 0;
-
-		// set the matched item as active
-		fabricator.dom.menuItems[index].classList.add('f-active');
 
 	};
 

--- a/src/assets/fabricator/scripts/fabricator.js
+++ b/src/assets/fabricator/scripts/fabricator.js
@@ -101,7 +101,10 @@ fabricator.setActiveItem = function () {
 	var setActive = function () {
 
 		// get current file and hash without first slash
-		var current = (window.location.pathname + window.location.hash).replace(/^\//g, ''),
+		var current = (window.location.pathname + window.location.hash).replace(/(^\/)(.+?)(#[\w\-\.]+)?$/ig, function (match, slash, file, hash) {
+		    	hash = hash || '';
+		    	return file + hash.split('.')[0];
+			}) || 'index.html',
 			href;
 
 		// find the current section in the items array
@@ -114,8 +117,7 @@ fabricator.setActiveItem = function () {
 
 			if (href === current) {
 				item.classList.add('f-active');
-			}
-			else {
+			} else {
 				item.classList.remove('f-active');
 			}
 


### PR DESCRIPTION
Would that solution be okay? I’m now comparing both filename and hash.

To get a correspondance between the menu item and the URL, I had to remove the first slash (coming from `location.pathname`. You might notice that I also remove the one from items `href` to be careful. I know it’s not necessary with Fabricator current code but in my own toolkit I had to add slashes at the beginning of every URLs in `f-menu.html`. Otherwise when you’re in a subtree (for example `pages/page.html`) all links to root files are broken.

Did I do something wrong or do you think it’s a bug that should be fixed?