### PR TITLE
Adding target attribute to pages

### DIFF
--- a/src/views/layouts/includes/f-menu.html
+++ b/src/views/layouts/includes/f-menu.html
@@ -28,7 +28,7 @@
 			<ul>
 				{{#each items}}
 				<li>
-					<a href="{{@../key}}/{{@key}}.html">{{name}}</a>
+					<a href="{{@../key}}/{{@key}}.html" target="_blank">{{name}}</a>
 				</li>
 				{{/each}}
 			</ul>

--- a/src/views/pages.html
+++ b/src/views/pages.html
@@ -8,7 +8,7 @@ fabricator: true
 {{#each views.pages.items}}
 
 	<li>
-		<a href="pages/{{@key}}.html" class="f-item-heading">{{name}}</a>
+		<a href="pages/{{@key}}.html" class="f-item-heading" target="_blank">{{name}}</a>
 	</li>
 
 {{/each}}


### PR DESCRIPTION
One issue with the way that the pages are right now inside fabricator is that once you click one a link to one, you no longer have access to the menu. I understand why you would not want access as you want to see the page in it's true state. One alternative approach we have added is to just add target="_blank" to these links so that you open them in a new window and they are separate from the toolkit window. I think this would be a great simple modification to core.