### PR TITLE
[CONFIG] Added gulpif on toolkit styles sourcemap generation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,11 +63,11 @@ gulp.task('styles:fabricator', function () {
 
 gulp.task('styles:toolkit', function () {
 	gulp.src(config.src.styles.toolkit)
-		.pipe(sourcemaps.init())
+		.pipe(gulpif(config.dev, sourcemaps.init()))
 		.pipe(sass().on('error', sass.logError))
 		.pipe(prefix('last 1 version'))
 		.pipe(gulpif(!config.dev, csso()))
-		.pipe(sourcemaps.write())
+		.pipe(gulpif(config.dev, sourcemaps.write()))
 		.pipe(gulp.dest(config.dest + '/assets/toolkit/styles'))
 		.pipe(gulpif(config.dev, reload({stream:true})));
 });


### PR DESCRIPTION
Hey there,

I've added gulpif ( with config.dev condition ) on the sourcemaps generation for the toolkit styles. 
This way the sourcemap is generated when running ```$ npm start``` and not when running a build with ```$ npm run build```.

I think it's useful to have this in place by default, since we might not want to have the sourcemap for production-ready builds.