### PR TITLE
Add Keyboard Shortcut for Menu

### DIFF
--- a/src/assets/fabricator/scripts/fabricator.js
+++ b/src/assets/fabricator/scripts/fabricator.js
@@ -156,6 +156,14 @@ fabricator.menuToggle = function () {
 		}
 	};
 
+	// toggle classes on ctrl + m press
+	document.onkeydown = function (e) {
+	  e = e || event
+	  if (e.ctrlKey && e.keyCode == 'M'.charCodeAt(0)) {
+		toggleClasses();
+	  }
+	}
+
 	// toggle classes on click
 	toggle.addEventListener('click', function () {
 		toggleClasses();

--- a/src/assets/fabricator/scripts/fabricator.js
+++ b/src/assets/fabricator/scripts/fabricator.js
@@ -158,10 +158,10 @@ fabricator.menuToggle = function () {
 
 	// toggle classes on ctrl + m press
 	document.onkeydown = function (e) {
-	  e = e || event
-	  if (e.ctrlKey && e.keyCode == 'M'.charCodeAt(0)) {
-		toggleClasses();
-	  }
+		e = e || event
+		if (e.ctrlKey && e.keyCode == 'M'.charCodeAt(0)) {
+			toggleClasses();
+		}
 	}
 
 	// toggle classes on click


### PR DESCRIPTION
Thinking through #220 i thought one way to rectify this UX issue would be to add a keyboard shortcut to the menuToggle. By doing this you are able to toggle the menu open and closed without having to scroll all the way to the top to press the menu button. The key code that I used was CTRL + m. I thought this made the most sense and was the least obtrusive. What do you think?