### PR TITLE
Add destination of compiled views

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -108,7 +108,8 @@ gulp.task('favicon', function () {
 // assemble
 gulp.task('assemble', function (done) {
 	assemble({
-		logErrors: config.dev
+		logErrors: config.dev,
+		dest: config.dest
 	});
 	done();
 });


### PR DESCRIPTION
Add destination of compiled views for assemble

Without this option, if you change `config.dest` with another values, the toolkit and fabricators files follow the change but the views are still compiled in `dist`.