### PR TITLE
adding `box-sizing: border-box` to fix default color-chips rendering on…

### DIFF
--- a/src/assets/fabricator/styles/partials/_color-chips.scss
+++ b/src/assets/fabricator/styles/partials/_color-chips.scss
@@ -16,6 +16,7 @@
 	font-size: 0.75em;
 	padding: 1em;
 	margin-bottom: 2em;
+  box-sizing: border-box;
 
 	@media (min-width: 60em) {
 		flex-basis: 13em;


### PR DESCRIPTION
… 'mobile' from causing horizontal scrolling